### PR TITLE
feat: add proxy configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ Configure which requests should bypass CORS:
 window.CORSFetch.config({
   include: [/^https?:\/\//i], // Process all HTTP requests (default)
   exclude: ["https://api.openai.com/v1/chat/completions"], // Skip CORS bypass
+  // Enabling a proxy for fetch requests without proxy configuration
+  // see https://v2.tauri.app/reference/javascript/http/#proxy-1
+  proxy: {
+    all: "socks5://127.0.0.1:7890",
+  }
 });
 ```
 

--- a/api-iife.js
+++ b/api-iife.js
@@ -3,6 +3,7 @@ class CORSFetch {
   _config = {
     include: [],
     exclude: [],
+    proxy: undefined,
   };
 
   constructor() {
@@ -15,6 +16,7 @@ class CORSFetch {
     this._config = {
       include: config.include || [],
       exclude: config.exclude || [],
+      proxy: config.proxy || undefined,
     };
   }
 
@@ -71,7 +73,7 @@ class CORSFetch {
 
       const maxRedirections = init?.maxRedirections;
       const connectTimeout = init?.connectTimeout;
-      const proxy = init?.proxy;
+      const proxy = init?.proxy ? init.proxy : this._config.proxy;
 
       // Remove these fields before creating the request
       if (init) {

--- a/example/src/main.js
+++ b/example/src/main.js
@@ -15,6 +15,9 @@ async function fetchData() {
 window.CORSFetch.config({
   include: [/^https?:\/\//i],
   exclude: ["https://api.openai.com/v1/chat/completions"],
+  proxy: {
+    all: "socks5://127.0.0.1:7890",
+  },
 });
 
 window.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
Enabling a proxy for `fetch` requests without proxy configuration.


Closes #10 